### PR TITLE
Use fixed positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img width="801" height="auto" alt="preview" src="https://user-images.githubusercontent.com/583202/48219897-d3d0b680-e35b-11e8-9ad6-356fa14eeeb9.png">
+  <img width="801" height="auto" alt="preview" src="https://user-images.githubusercontent.com/105849/72086453-f00c1280-32d4-11ea-80bc-f142ab6e75d7.png">
 </p>
 
 <p align="center">
@@ -13,39 +13,44 @@
 
 It's easy to get disoriented when your application runs in multiple environments. This package checks the domain & adds a simple indicator to let you know when you're not on production. It looks for the following environments out of the box:
 
-* Local development, at `localhost` or `.test` domains.
-* Development environments, at `dev.` or `*-dev.` subdomains.
-* QA environments, at `qa.` or `*-qa.` subdomains.
-* Preview environments, at `preview.` or `*-preview.` subdomains.
+- Local development, at `localhost` or `.test` domains.
+- Development environments, at `dev.` or `*-dev.` subdomains.
+- QA environments, at `qa.` or `*-qa.` subdomains.
+- Preview environments, at `preview.` or `*-preview.` subdomains.
 
 ### Usage
+
 If you're building your application with [Webpack](https://webpack.js.org), [Create React App](https://facebook.github.io/create-react-app/), or a similar tool, simply import this module:
 
 ```js
-require('environment-badge')();
+require("environment-badge")();
 ```
 
 For applications without a front-end build system, you can embed this script from [unpkg](https://unpkg.com):
 
 ```html
-<script type="text/javascript" src="https://unpkg.com/environment-badge@^1.0.0/dist/bundle.js"></script>
+<script
+  type="text/javascript"
+  src="https://unpkg.com/environment-badge@^1.0.0/dist/bundle.js"
+></script>
 ```
 
 ### Advanced Usage
+
 You can customize what environments are checked for by providing an array. For example:
 
 ```js
-require('environment-badge')([
+require("environment-badge")([
   {
-    displayName: 'local',
-    host: /(^localhost$|\.test$)/,
+    displayName: "local",
+    host: /(^localhost$|\.test$)/
   },
   {
-    displayName: 'staging',
+    displayName: "staging",
     host: /^([a-z0-9-]*-)?staging\./,
-    backgroundColor: '#000000',
-    foregroundColor: '#fcd116',
-  },
+    backgroundColor: "#000000",
+    foregroundColor: "#fcd116"
+  }
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It's easy to get disoriented when your application runs in multiple environments
 If you're building your application with [Webpack](https://webpack.js.org), [Create React App](https://facebook.github.io/create-react-app/), or a similar tool, simply import this module:
 
 ```js
-require("environment-badge")();
+require('environment-badge')();
 ```
 
 For applications without a front-end build system, you can embed this script from [unpkg](https://unpkg.com):
@@ -40,17 +40,17 @@ For applications without a front-end build system, you can embed this script fro
 You can customize what environments are checked for by providing an array. For example:
 
 ```js
-require("environment-badge")([
+require('environment-badge')([
   {
-    displayName: "local",
-    host: /(^localhost$|\.test$)/
+    displayName: 'local',
+    host: /(^localhost$|\.test$)/,
   },
   {
-    displayName: "staging",
+    displayName: 'staging',
     host: /^([a-z0-9-]*-)?staging\./,
-    backgroundColor: "#000000",
-    foregroundColor: "#fcd116"
-  }
+    backgroundColor: '#000000',
+    foregroundColor: '#fcd116',
+  },
 ]);
 ```
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build": "npm run build:browser && npm run build:cjs",
     "build:browser": "NODE_ENV=production rollup --config --environment NODE_ENV",
     "build:cjs": "babel src -d lib --plugins transform-es2015-modules-commonjs,add-module-exports",
+    "format": "prettier --write \"**/*.{js,md}\"",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "babel": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,16 +1,14 @@
 import babel from 'rollup-plugin-babel';
-import { uglify } from "rollup-plugin-uglify";
+import { uglify } from 'rollup-plugin-uglify';
 import nodeResolve from 'rollup-plugin-node-resolve';
 
-export default ({
+export default {
   input: 'src/register.js',
-  plugins: [
-    babel({runtimeHelpers: true}),
-    nodeResolve(),
-    uglify(),
+  plugins: [babel({ runtimeHelpers: true }), nodeResolve(), uglify()],
+  output: [
+    {
+      file: 'dist/bundle.js',
+      format: 'iife',
+    },
   ],
-  output: [{
-    file: 'dist/bundle.js',
-    format: 'iife'
-  }]
-});
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,51 +1,60 @@
 const DEFAULT_ENVIRONMENTS = [
   {
-    displayName: 'local',
-    host: /(^localhost(:[0-9]+)?$|\.test$)/,
+    displayName: "local",
+    host: /(^localhost(:[0-9]+)?$|\.test$)/
   },
   {
-    displayName: 'dev',
+    displayName: "dev",
     host: /^([a-z0-9-]*-)?dev\./,
-    backgroundColor: '#fcd116',
+    backgroundColor: "#fcd116"
   },
   {
-    displayName: 'qa',
+    displayName: "qa",
     host: /^([a-z0-9-]*-)?qa\./,
-    backgroundColor: '#23b7fb',
-    foregroundColor: '#fff',
+    backgroundColor: "#23b7fb",
+    foregroundColor: "#fff"
   },
   {
-    displayName: 'preview',
+    displayName: "preview",
     host: /^([a-z0-9-]*-)?preview\./,
-    backgroundColor: '#22BC66',
-    foregroundColor: '#fff',
+    backgroundColor: "#22BC66",
+    foregroundColor: "#fff"
   }
-]
+];
 
 export default (environments = DEFAULT_ENVIRONMENTS) => {
   let environment = null;
+
   for (let i = 0; i < environments.length; i++) {
     if (environments[i].host.test(window.location.host)) {
-      environment = environments[i]
+      environment = environments[i];
       break;
     }
   }
 
   // Create the badge and add it to the page:
   if (environment) {
-    const { displayName, backgroundColor = '#ddd', foregroundColor = '#000' } = environment;
-    const environmentBadge = document.createElement('div');
-    environmentBadge.innerHTML = '\
-        <div style="display: block; position: absolute; top: -50px; left: -50px; width: 100px; height: 100px; background: ' + backgroundColor + '; color: ' + foregroundColor + '; transform: rotate(-45deg); z-index: 9999;">\
+    const {
+      displayName,
+      backgroundColor = "#000", //#cbd5e0
+      foregroundColor = "#fff"
+    } = environment;
+    const environmentBadge = document.createElement("div");
+    environmentBadge.innerHTML =
+      '\
+        <div style="display: block; position: fixed; top: -50px; left: -50px; width: 100px; height: 100px; background: ' +
+      backgroundColor +
+      "; color: " +
+      foregroundColor +
+      '; transform: rotate(-45deg); z-index: 9999;">\
           <span style="display: block; position: relative; top: 85%; font-size: 12px; text-align: center; font-weight: bold; text-transform: uppercase; transform: translateY(-50%); cursor: default;">\
-            ' + displayName + '\
+            ' +
+      displayName +
+      "\
           </span>\
         </div>\
-      ';
+      ";
 
-    // Apply badge to Forge container if it exists, or the body:
-    const container = document.querySelector('.chrome > .wrapper') || document.body;
-    container.appendChild(environmentBadge);
-    container.style.overflow = 'hidden'; // awkward, but required so badge doesn't overflow!
+    document.body.appendChild(environmentBadge);
   }
-}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -40,20 +40,13 @@ export default (environments = DEFAULT_ENVIRONMENTS) => {
       foregroundColor = '#fff',
     } = environment;
     const environmentBadge = document.createElement('div');
-    environmentBadge.innerHTML =
-      '\
-        <div style="display: block; position: fixed; top: -50px; left: -50px; width: 100px; height: 100px; background: ' +
-      backgroundColor +
-      '; color: ' +
-      foregroundColor +
-      '; transform: rotate(-45deg); z-index: 9999;">\
-          <span style="display: block; position: relative; top: 85%; font-size: 12px; text-align: center; font-weight: bold; text-transform: uppercase; transform: translateY(-50%); cursor: default;">\
-            ' +
-      displayName +
-      '\
-          </span>\
-        </div>\
-      ';
+    environmentBadge.innerHTML = `
+      <div style="display: block; position: fixed; top: -50px; left: -50px; width: 100px; height: 100px; background: ${backgroundColor}; color: ${foregroundColor}; transform: rotate(-45deg); z-index: 9999;">
+        <span style="display: block; position: relative; top: 85%; font-size: 12px; text-align: center; font-weight: bold; text-transform: uppercase; transform: translateY(-50%); cursor: default;">
+          ${displayName}
+        </span>
+      </div>
+    `;
 
     document.body.appendChild(environmentBadge);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,25 @@
 const DEFAULT_ENVIRONMENTS = [
   {
-    displayName: "local",
-    host: /(^localhost(:[0-9]+)?$|\.test$)/
+    displayName: 'local',
+    host: /(^localhost(:[0-9]+)?$|\.test$)/,
   },
   {
-    displayName: "dev",
+    displayName: 'dev',
     host: /^([a-z0-9-]*-)?dev\./,
-    backgroundColor: "#fcd116"
+    backgroundColor: '#fcd116',
   },
   {
-    displayName: "qa",
+    displayName: 'qa',
     host: /^([a-z0-9-]*-)?qa\./,
-    backgroundColor: "#23b7fb",
-    foregroundColor: "#fff"
+    backgroundColor: '#23b7fb',
+    foregroundColor: '#fff',
   },
   {
-    displayName: "preview",
+    displayName: 'preview',
     host: /^([a-z0-9-]*-)?preview\./,
-    backgroundColor: "#22BC66",
-    foregroundColor: "#fff"
-  }
+    backgroundColor: '#22BC66',
+    foregroundColor: '#fff',
+  },
 ];
 
 export default (environments = DEFAULT_ENVIRONMENTS) => {
@@ -36,24 +36,24 @@ export default (environments = DEFAULT_ENVIRONMENTS) => {
   if (environment) {
     const {
       displayName,
-      backgroundColor = "#000", //#cbd5e0
-      foregroundColor = "#fff"
+      backgroundColor = '#000',
+      foregroundColor = '#fff',
     } = environment;
-    const environmentBadge = document.createElement("div");
+    const environmentBadge = document.createElement('div');
     environmentBadge.innerHTML =
       '\
         <div style="display: block; position: fixed; top: -50px; left: -50px; width: 100px; height: 100px; background: ' +
       backgroundColor +
-      "; color: " +
+      '; color: ' +
       foregroundColor +
       '; transform: rotate(-45deg); z-index: 9999;">\
           <span style="display: block; position: relative; top: 85%; font-size: 12px; text-align: center; font-weight: bold; text-transform: uppercase; transform: translateY(-50%); cursor: default;">\
             ' +
       displayName +
-      "\
+      '\
           </span>\
         </div>\
-      ";
+      ';
 
     document.body.appendChild(environmentBadge);
   }

--- a/src/register.js
+++ b/src/register.js
@@ -1,11 +1,15 @@
-import badge from './index';
+import badge from "./index";
 
 // Simple 'DOMContentLoaded' helper, via http://youmightnotneedjquery.com/#ready:
 function ready(fn) {
-  if (document.attachEvent ? document.readyState === "complete" : document.readyState !== "loading"){
+  if (
+    document.attachEvent
+      ? document.readyState === "complete"
+      : document.readyState !== "loading"
+  ) {
     fn();
   } else {
-    document.addEventListener('DOMContentLoaded', () => fn());
+    document.addEventListener("DOMContentLoaded", () => fn());
   }
 }
 

--- a/src/register.js
+++ b/src/register.js
@@ -1,15 +1,15 @@
-import badge from "./index";
+import badge from './index';
 
 // Simple 'DOMContentLoaded' helper, via http://youmightnotneedjquery.com/#ready:
 function ready(fn) {
   if (
     document.attachEvent
-      ? document.readyState === "complete"
-      : document.readyState !== "loading"
+      ? document.readyState === 'complete'
+      : document.readyState !== 'loading'
   ) {
     fn();
   } else {
-    document.addEventListener("DOMContentLoaded", () => fn());
+    document.addEventListener('DOMContentLoaded', () => fn());
   }
 }
 


### PR DESCRIPTION
This PR updates the badge to use "fixed" positioning, which makes it easier to always know which environment you are on, since the badge follows you as you scroll on a page. It also removes a rule which would add `overflow: hidden` to a container or the `body`, but this proved to be a conflicting rule that could cause scrolling issues. With fixed positioning, this is no longer needed and no longer a conflicting rule 💃 

It also updates the "local" badge color to black to make it more apparent, since the gray could sometimes get lost with our DS site background, now that the badge is fixed to the top left of the page.

Also, Prettier kind of took over and made a bunch of code-style fixes 🎨 

![new local badge color](https://user-images.githubusercontent.com/105849/72086453-f00c1280-32d4-11ea-80bc-f142ab6e75d7.png)